### PR TITLE
Change "argument" to "property"

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ Features
 arg-err supports:
 
 - validating against a type name (e.g. `string` or `number`)
-- validating a string argument against a regex
+- validating a string property against a regex
 - validating against multiple possible types defined as an array (e.g. `["string", "number"]`)
 - validating against a nested schema
 - validating against a function for slightly more complex logic
-- optional arguments
+- optional properties
 
 Installing
 ----
@@ -62,7 +62,7 @@ frobnicate({
   foo: 123,
   bar: 456
 }, function (err) {
-  assert.equal(err, "expected argument bar to be of type string (was number), expected argument baz to be of type regexp");
+  assert.equal(err, "expected property bar to be of type string (was number), expected property baz to be of type regexp");
 });
 ```
 
@@ -75,10 +75,10 @@ var args = { foo: { bar: 123 }, baz: "bla" },
     baz: /^qux$/
   });
 
-assert.equal(err, "expected argument foo.bar to be of type string (was number), expected argument baz to match /^qux$/ (was \"bla\")");
+assert.equal(err, "expected property foo.bar to be of type string (was number), expected property baz to match /^qux$/ (was \"bla\")");
 ```
 
-### Multiple possible arguments
+### Multiple possible properties
 
 ```javascript
 var args = { foo: /reg[exp]$/ },
@@ -86,7 +86,7 @@ var args = { foo: /reg[exp]$/ },
     foo: ["string", "number"]
   });
 
-assert.equal(err, "expected argument foo to be of type string or number (was regexp)");
+assert.equal(err, "expected property foo to be of type string or number (was regexp)");
 ```
 
 ### Complex validation
@@ -105,12 +105,12 @@ var args = { foo: 13 },
     foo: isEven
   });
 
-assert.equal(err, "expected argument foo to pass isEven");
+assert.equal(err, "expected property foo to pass isEven");
 ```
 
-### Optional arguments
+### Optional properties
 
-Optional arguments are handled exactly the same as normal ones, except no error is thrown if the property is undefined.
+Optional properties are handled exactly the same as normal ones, except no error is thrown if the property is undefined.
 
 ```javascript
 var args = { foo: 123, bar: "bla" },
@@ -120,7 +120,7 @@ var args = { foo: 123, bar: "bla" },
     bar: "number"
   });
 
-assert.equal(err, "expected optional argument bar to be of type number (was string)");
+assert.equal(err, "expected optional property bar to be of type number (was string)");
 ```
 
 License

--- a/dist/arg-err.js
+++ b/dist/arg-err.js
@@ -1,19 +1,18 @@
-!function(e){if("object"==typeof exports)module.exports=e();else if("function"==typeof define&&define.amd)define(e);else{var f;"undefined"!=typeof window?f=window:"undefined"!=typeof global?f=global:"undefined"!=typeof self&&(f=self),f.argErr=e()}}(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);throw new Error("Cannot find module '"+o+"'")}var f=n[o]={exports:{}};t[o][0].call(f.exports,function(e){var n=t[o][1][e];return s(n?n:e)},f,f.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(_dereq_,module,exports){
-/*jslint indent: 2, node: true, continue: true*/
+!function(e){if("object"==typeof exports&&"undefined"!=typeof module)module.exports=e();else if("function"==typeof define&&define.amd)define([],e);else{var f;"undefined"!=typeof window?f=window:"undefined"!=typeof global?f=global:"undefined"!=typeof self&&(f=self),f.argErr=e()}}(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
 "use strict";
 
-var kindof = _dereq_("kindof");
+var kindof = require("kindof");
 
 function regexpErrMsg(args) {
   return "expected" + (args.optional ? " optional" : "")
-    + " argument " + args.propName
+    + " property " + args.propName
     + " to match " + args.inputPattern.toString()
     + " (was \"" + args.input + "\")";
 }
 
 function errMsg(args) {
   return "expected" + (args.optional ? " optional" : "")
-    + " argument " + args.propName
+    + " property " + args.propName
     + " to be of type " + args.schemaType
     + " (was " + args.inputType + ")";
 }
@@ -30,15 +29,16 @@ function functionErrMsg(args) {
   }
 
   return "expected" + (args.optional ? " optional" : "")
-    + " argument " + args.propName
+    + " property " + args.propName
     + " to pass " + functionName;
 }
 
 function recursiveFlatten(array, result) {
-  var i,
-    result = result || [];
+  var i;
 
-  for (i = 0; i < array.length; i++) {
+  result = result || [];
+
+  for (i = 0; i < array.length; i += 1) {
     if (kindof(array[i]) === "array") {
       recursiveFlatten(array[i], result);
     } else {
@@ -78,6 +78,26 @@ function getErrs(args) {
     passedSpecialCases,
     errs = [];
 
+  // used for array schema types
+  // where all we need is to pass a single array element
+  function someSchemasValidate(propName) {
+    return schema[propName].some(function (possibleType) {
+      var tempInput = {},
+        tempSchema = {},
+        tempErrs;
+
+      tempInput[propName] = input[propName];
+      tempSchema[propName] = possibleType;
+      tempErrs = getErrs({
+        input: tempInput,
+        schema: tempSchema,
+        optional: optional
+      });
+
+      return tempErrs.length === 0;
+    });
+  }
+
   for (prop in schema) {
     if (schema.hasOwnProperty(prop)) {
       passedSpecialCases = false;
@@ -98,21 +118,7 @@ function getErrs(args) {
         // whether some of them validate
         //
         // if at least one validates, there's no error
-        if (schema[prop].some(function (possibleType) {
-            var tempInput = {},
-              tempSchema = {},
-              tempErrs;
-
-            tempInput[prop] = input[prop];
-            tempSchema[prop] = possibleType;
-            tempErrs = getErrs({
-              input: tempInput,
-              schema: tempSchema,
-              optional: optional
-            });
-
-            return tempErrs.length === 0;
-          })) {
+        if (someSchemasValidate(prop)) {
           passedSpecialCases = true;
         }
       } else if (schemaType === "object") {
@@ -194,24 +200,25 @@ exports.err = function (input, schema, optionalSchema) {
   return errs.length ? errs.join(", ") : null;
 };
 
-},{"kindof":2}],2:[function(_dereq_,module,exports){
+},{"kindof":2}],2:[function(require,module,exports){
 if (typeof module != "undefined") module.exports = kindof
 
 function kindof(obj) {
+  var type
   if (obj === undefined) return "undefined"
   if (obj === null) return "null"
 
-  switch (Object.prototype.toString.call(obj)) {
-    case "[object Boolean]": return "boolean"
-    case "[object Number]": return "number"
-    case "[object String]": return "string"
-    case "[object RegExp]": return "regexp"
-    case "[object Date]": return "date"
-    case "[object Array]": return "array"
-    default: return typeof obj
+  switch (type = typeof obj) {
+    case "object":
+      switch (Object.prototype.toString.call(obj)) {
+        case "[object RegExp]": return "regexp"
+        case "[object Date]": return "date"
+        case "[object Array]": return "array"
+      }
+
+    default: return type
   }
 }
 
-},{}]},{},[1])
-(1)
+},{}]},{},[1])(1)
 });

--- a/index.js
+++ b/index.js
@@ -4,14 +4,14 @@ var kindof = require("kindof");
 
 function regexpErrMsg(args) {
   return "expected" + (args.optional ? " optional" : "")
-    + " argument " + args.propName
+    + " property " + args.propName
     + " to match " + args.inputPattern.toString()
     + " (was \"" + args.input + "\")";
 }
 
 function errMsg(args) {
   return "expected" + (args.optional ? " optional" : "")
-    + " argument " + args.propName
+    + " property " + args.propName
     + " to be of type " + args.schemaType
     + " (was " + args.inputType + ")";
 }
@@ -28,7 +28,7 @@ function functionErrMsg(args) {
   }
 
   return "expected" + (args.optional ? " optional" : "")
-    + " argument " + args.propName
+    + " property " + args.propName
     + " to pass " + functionName;
 }
 

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "utility"
   ],
   "scripts": {
-    "test": "./node_modules/.bin/mocha -R spec test/arg-err.js",
-    "pretest": "./node_modules/.bin/jslint index.js && ./node_modules/.bin/jslint test/arg-err.js",
-    "bundle": "./node_modules/.bin/browserify index.js -s arg-err -o dist/arg-err.js"
+    "test": "mocha -R spec test/arg-err.js",
+    "pretest": "jslint index.js test/arg-err.js",
+    "bundle": "browserify index.js -s arg-err -o dist/arg-err.js"
   },
   "dependencies": {
     "kindof": "*"

--- a/test/arg-err.js
+++ b/test/arg-err.js
@@ -17,34 +17,34 @@ describe("arg-err", function () {
       err = arg.err(input, { foo: "number" });
 
     should.exist(err);
-    err.should.equal("expected argument foo to be of type number (was string)");
+    err.should.equal("expected property foo to be of type number (was string)");
   });
   it("should give an error for missing args", function () {
     var input = { foo: 2 },
       err = arg.err(input, { foo: "number", bar: "string" });
 
     should.exist(err);
-    err.should.equal("expected argument bar to be of type string (was undefined)");
+    err.should.equal("expected property bar to be of type string (was undefined)");
   });
   it("should give multiple errors on multiple lines", function () {
     var input = { foo: "2", bar: 123 },
       err = arg.err(input, { foo: "number", bar: "string" });
 
-    err.should.equal("expected argument foo to be of type number (was string), expected argument bar to be of type string (was number)");
+    err.should.equal("expected property foo to be of type number (was string), expected property bar to be of type string (was number)");
   });
   it("should be able to validate nested objects", function () {
     var input = { foo: "2", bar: { baz: { bat: 1234 } } },
       schema = { foo: "string", bar: { baz: { bat: "string" } } },
       err = arg.err(input, schema);
 
-    err.should.containEql("expected argument bar.baz.bat to be of type string (was number)");
+    err.should.containEql("expected property bar.baz.bat to be of type string (was number)");
   });
   it("should report incorrectly typed objects in the input without recursing", function () {
     var input = { foo: "2", bar: 123 },
       schema = { foo: "string", bar: { baz: { bat: "string" } } },
       err = arg.err(input, schema);
 
-    err.should.containEql("expected argument bar to be of type object (was number)");
+    err.should.containEql("expected property bar to be of type object (was number)");
   });
   it("should validate using regex", function () {
     var input = { foo: "hello" },
@@ -59,23 +59,23 @@ describe("arg-err", function () {
       schema = { foo: /^hel+o$/ },
       err = arg.err(input, schema);
 
-    err.should.containEql("expected argument foo to match /^hel+o$/ (was \"goodbye\")");
+    err.should.containEql("expected property foo to match /^hel+o$/ (was \"goodbye\")");
   });
   it("should assume regex schema elements are string type", function () {
     var input = { foo: 123 },
       schema = { foo: /^hel+o$/ },
       err = arg.err(input, schema);
 
-    err.should.containEql("expected argument foo to be of type string (was number)");
+    err.should.containEql("expected property foo to be of type string (was number)");
   });
-  it("should accept a third argument for an optional schema", function () {
+  it("should accept a third property for an optional schema", function () {
     var input = { foo: 123, bar: 456 },
       schema = { foo: "number" },
       optSchema = { bar: "string" },
       err = arg.err(input, schema, optSchema);
 
     should.exist(err);
-    err.should.containEql("expected optional argument bar to be of type string (was number)");
+    err.should.containEql("expected optional property bar to be of type string (was number)");
   });
   it("should not give an error for a missing optional arg", function () {
     var input = { foo: 123 },
@@ -94,13 +94,13 @@ describe("arg-err", function () {
     should.not.exist(err);
     (err === null).should.eql(true);
   });
-  it("should throw an error if an argument doesn't match any of the options", function () {
+  it("should throw an error if an property doesn't match any of the options", function () {
     var input = { foo: /reg[ex]/ },
       schema = { foo: ["string", "number"] },
       err = arg.err(input, schema);
 
     should.exist(err);
-    err.should.containEql("expected argument foo to be of type string or number (was regexp)");
+    err.should.containEql("expected property foo to be of type string or number (was regexp)");
   });
   it("should still work if one of the multiple args is an object", function () {
     var input = { foo: /reg[ex]/ },
@@ -108,7 +108,7 @@ describe("arg-err", function () {
       err = arg.err(input, schema);
 
     should.exist(err);
-    err.should.containEql("expected argument foo to be of type string or object (was regexp)");
+    err.should.containEql("expected property foo to be of type string or object (was regexp)");
   });
   it("should error out if passed a weird type on the schema", function () {
     var input = { foo: /reg[ex]/ },
@@ -142,7 +142,7 @@ describe("arg-err", function () {
       err = arg.err(input, schema);
 
     should.exist(err);
-    err.should.containEql("expected argument foo to pass isEven");
+    err.should.containEql("expected property foo to pass isEven");
   });
   it("should be able to validate schemas with nested objects", function () {
     var input = {


### PR DESCRIPTION
Hi Andrey,

I'm loving using arg-err. It's great :+1:  But one gripe that's been bugging me a bit...
object properties are constantly referred to as arguments in the module. This doesn't
seem, well, prop-err.

You probably don't want to change this, but in case you do, here's a pull request of the
changes that I made to get it to output the appropriate string.

If you don't want to accept the pull-request I'm happy to keep my fork and rename it
prop-err.

Anyway, hope you're having a nice day :)

xxx
